### PR TITLE
Multiple configurations iterator

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -5,3 +5,12 @@
   additional_dependencies: [renovate@32.105.2]
   entry: renovate-config-validator
   files: '(^|/).?renovate(?:rc)?(?:\.json5?)?$'
+- id: renovate-config-validator-iter
+  name: renovate-config-validator
+  description: Validate Renovate config
+  language: node
+  additional_dependencies: [renovate@32.105.2]
+  entry: bash -c 'for f in ${@:0}; do renovate-config-validator $f; done'
+  files: '(^|/).?renovate(?:rc)?(?:\.json5?)?$'
+  require_serial: true
+  pass_filenames: true

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -12,5 +12,3 @@
   additional_dependencies: [renovate@32.105.2]
   entry: bash -c 'for f in ${@:0}; do renovate-config-validator $f; done'
   files: '(^|/).?renovate(?:rc)?(?:\.json5?)?$'
-  require_serial: true
-  pass_filenames: true

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ repos:
   - repo: github.com/renovatebot/pre-commit-hooks
     rev: 32.105.2
     hooks:
-      - id: renovate-config-validator
+      - id: renovate-config-validator-iter
         files: |
           (?x)^(
             (^|.*/).?renovate(?:rc)?(?:\.json5?)?$|

--- a/README.md
+++ b/README.md
@@ -13,3 +13,18 @@ repos:
     hooks:
       - id: renovate-config-validator
 ```
+
+You can also use `renovate-config-validator-iter` in a project with multiple configurations by listing the configurations in the [files](https://pre-commit.com/#hooks-files) field
+
+```yaml
+repos:
+  - repo: github.com/renovatebot/pre-commit-hooks
+    rev: 32.105.2
+    hooks:
+      - id: renovate-config-validator
+        files: |
+          (?x)^(
+            (^|.*/).?renovate(?:rc)?(?:\.json5?)?$|
+            ^default\.json
+          )
+```


### PR DESCRIPTION
Renovate supports [Sharable Configuration Presets](https://docs.renovatebot.com/config-presets/) and a repository might hold multiple configurations (e.g. `github>abc/foo:xyz` will extend `xyz.json` in the default branch) along side renovate configuration itself.

Right now, `renovate-config-validator` does not accept more than a single file. Instead, `renovate-config-validator` needs to be invoked for each configuration in the repository.

Having `renovate-config-validator` accept multiple files would be nice, but it will take some time until it will happen if it will happen at all.

Adding a hook that iterates on the detected files (by overloading [`files`](https://pre-commit.com/#hooks-files)) and invoke `renovate-config-validator` for each of them.