### PR TITLE
fix: add https to repository url

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Even though it is a Node-based hook, it works [without any system-level dependen
 
 ```yaml
 repos:
-  - repo: github.com/renovatebot/pre-commit-hooks
+  - repo: https://github.com/renovatebot/pre-commit-hooks
     rev: 32.204.5
     hooks:
       - id: renovate-config-validator


### PR DESCRIPTION
pre-commit failed without the https protocol prefix.

```console
[INFO] Initializing environment for github.com/renovatebot/pre-commit-hooks.
An unexpected error has occurred: CalledProcessError: command: ('/usr/bin/git', 'fetch', 'origin', '--tags')
return code: 128
expected return code: 0
stdout: (none)
stderr:
    fatal: 'github.com/renovatebot/pre-commit-hooks' does not appear to be a git repository
    fatal: Could not read from remote repository.
    
    Please make sure you have the correct access rights
    and the repository exists.
```