### PR TITLE
Expand file regex to also include global config.js

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,4 +4,4 @@
   language: node
   additional_dependencies: [renovate@37.286.0]
   entry: renovate-config-validator
-  files: '((^|/).?renovate(?:rc)?(?:\.json5?)?$|^config.js$)'
+  files: '((^|/).?renovate(?:rc)?(?:\.json5?)?|^config.js)$'

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,4 +4,4 @@
   language: node
   additional_dependencies: [renovate@37.286.0]
   entry: renovate-config-validator
-  files: '(^|/).?renovate(?:rc)?(?:\.json5?)?$'
+  files: '((^|/).?renovate(?:rc)?(?:\.json5?)?$|^config.js$)'


### PR DESCRIPTION
An attempt to solve global `config.js` is not included  by the file regex.

Solve this issue https://github.com/renovatebot/pre-commit-hooks/issues/1946